### PR TITLE
Implements Session.destroy method which stops sending bosh requests and aborts the current requests

### DIFF
--- a/lib/bosh.js
+++ b/lib/bosh.js
@@ -29,6 +29,7 @@ function BOSHConnection (opts) {
     }
   }
   this.currentRequests = 0
+  this.activeRequests = []
   this.queue = []
   this.rid = Math.ceil(Math.random() * 9999999999)
 
@@ -161,6 +162,19 @@ BOSHConnection.prototype.end = function (stanzas) {
   }.bind(this))
 }
 
+BOSHConnection.prototype.destroy = function () {
+  delete this.sid
+  this.activeRequests.forEach(function (request) {
+    request.abort();
+  })
+  this.activeRequests = []
+  this.shutdown = true
+  this.queue = []
+  this.emit('disconnect')
+  this.emit('end')
+  this.emit('close')
+}
+
 BOSHConnection.prototype.maxHTTPRetries = 5
 
 BOSHConnection.prototype.request = function (attrs, children, cb, retry) {
@@ -180,7 +194,7 @@ BOSHConnection.prototype.request = function (attrs, children, cb, retry) {
 
   debug('send bosh request:' + boshEl.toString())
 
-  request({
+  var currentRequest = request({
     uri: this.boshURL,
     method: 'POST',
     headers: { 'Content-Type': this.contentType },
@@ -188,7 +202,9 @@ BOSHConnection.prototype.request = function (attrs, children, cb, retry) {
   },
     function (err, res, body) {
       that.currentRequests--
-
+      var currentRequestIndex = that.activeRequests.indexOf(currentRequest)
+      if(currentRequestIndex != -1)
+        that.activeRequests.splice(currentRequestIndex, 1);
       if (err) {
         if (retry < that.maxHTTPRetries) {
           return that.request(attrs, children, cb, retry + 1)
@@ -218,6 +234,7 @@ BOSHConnection.prototype.request = function (attrs, children, cb, retry) {
       }
     }
   )
+  this.activeRequests.push(currentRequest);
   this.currentRequests++
 }
 

--- a/lib/bosh.js
+++ b/lib/bosh.js
@@ -165,7 +165,7 @@ BOSHConnection.prototype.end = function (stanzas) {
 BOSHConnection.prototype.destroy = function () {
   delete this.sid
   this.activeRequests.forEach(function (request) {
-    request.abort();
+    request.abort()
   })
   this.activeRequests = []
   this.shutdown = true
@@ -203,8 +203,9 @@ BOSHConnection.prototype.request = function (attrs, children, cb, retry) {
     function (err, res, body) {
       that.currentRequests--
       var currentRequestIndex = that.activeRequests.indexOf(currentRequest)
-      if(currentRequestIndex != -1)
-        that.activeRequests.splice(currentRequestIndex, 1);
+      if (currentRequestIndex != -1) {
+        that.activeRequests.splice(currentRequestIndex, 1)
+      }
       if (err) {
         if (retry < that.maxHTTPRetries) {
           return that.request(attrs, children, cb, retry + 1)
@@ -234,7 +235,7 @@ BOSHConnection.prototype.request = function (attrs, children, cb, retry) {
       }
     }
   )
-  this.activeRequests.push(currentRequest);
+  this.activeRequests.push(currentRequest)
   this.currentRequests++
 }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -203,6 +203,12 @@ Session.prototype.end = function () {
   }
 }
 
+Session.prototype.destroy = function () {
+  if (this.connection && this.connection.destroy) {
+    this.connection.destroy()
+  }
+}
+
 Session.prototype.onStanza = function () {}
 
 module.exports = Session


### PR DESCRIPTION
This method is almost the same as "end" except that it aborts the current requests and it isn't sending terminate packet. This should be useful for prebind. 