### PR TITLE
Use this object for session connect()

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -58,8 +58,6 @@ Session.prototype._setupSocketConnection = function (opts) {
 }
 
 Session.prototype._socketConnectionToHost = function (opts) {
-  var _this = this
-
   if (opts.legacySSL) {
     this.connection.allowTLS = false
     this.connection.connect({
@@ -70,9 +68,9 @@ Session.prototype._socketConnectionToHost = function (opts) {
           opts.credentials || {},
           function () {
             if (this.socket.authorized) {
-              _this.emit('connect', this.socket)
+              this.emit('connect', this.socket)
             } else {
-              _this.emit('error', 'unauthorized')
+              this.emit('error', 'unauthorized')
             }
           }.bind(this)
         )


### PR DESCRIPTION
I recognized con.startStream() function is not called  when session connect for initialization.

So I debugged and found out connect function is not bounded to "_this" correctly.

It might have caused by using local variable "var _this = this".
I think there are some problem about scope reference.