### PR TITLE
Allow passing websocket options through

### DIFF
--- a/lib/websockets.js
+++ b/lib/websockets.js
@@ -17,7 +17,7 @@ function WSConnection (opts) {
   this.url = opts.websocket.url
   this.jid = opts.jid
   this.xmlns = {}
-  this.websocket = new WebSocket(this.url, ['xmpp'])
+  this.websocket = new WebSocket(this.url, ['xmpp'], opts.websocket.options)
   this.websocket.onopen = this.onopen.bind(this)
   this.websocket.onmessage = this.onmessage.bind(this)
   this.websocket.onclose = this.onclose.bind(this)


### PR DESCRIPTION
This PR allows passing of websocket options. This allows configuration of the Faye websocket. In my case, I am using this to enable permessage-deflate compression. 